### PR TITLE
Add support for indoor temperature and humidity (intemp, inhum)

### DIFF
--- a/custom_components/cumulusmx/const.py
+++ b/custom_components/cumulusmx/const.py
@@ -38,7 +38,7 @@ DEFAULT_WEBTAGS = "temp,hum,dew,heatindex,press,rfall,rrate,wgust," \
                     "AirLinkAqiPm10_24hrOut,AirLinkAqiPm10_NowcastOut," \
                     "AirLinkTempOut,AirLinkHumOut,MulticastGoodCnt," \
                     "MulticastBadCnt,MulticastGoodPct,ProgramUpTime," \
-                    "SystemUpTime,version,build,timehhmmss,txbattery channel=1,txbattery channel=2"
+                    "SystemUpTime,version,build,timehhmmss,txbattery channel=1,txbattery channel=2,intemp,inhum"
 DEFAULT_UPDATE_INTERVAL = 60
 
 # Endpoint for reading sensors


### PR DESCRIPTION
Added two new sensor types to SENSOR_TYPES in const.py:
- intemp → Indoor Temperature
- inhum → Indoor Humidity

These webtags are standard in CumulusMX and allow Home Assistant to display indoor readings from Ecowitt and other supported weather stations.

Tested with:
- CumulusMX v4.6.4 build 4128
- Home Assistant 2025.10.x